### PR TITLE
fix: use the dot notation to extract nested objects in csv data

### DIFF
--- a/coverage/coverage-summary.json
+++ b/coverage/coverage-summary.json
@@ -1,3 +1,3 @@
-{"total": {"lines":{"total":19,"covered":17,"skipped":0,"pct":89.47},"statements":{"total":20,"covered":18,"skipped":0,"pct":90},"functions":{"total":8,"covered":7,"skipped":0,"pct":87.5},"branches":{"total":2,"covered":1,"skipped":0,"pct":50}}
-,"/home/ben/projects/react-admin-import-csv/src/csv-extractor.ts": {"lines":{"total":19,"covered":17,"skipped":0,"pct":89.47},"functions":{"total":8,"covered":7,"skipped":0,"pct":87.5},"statements":{"total":20,"covered":18,"skipped":0,"pct":90},"branches":{"total":2,"covered":1,"skipped":0,"pct":50}}
+{"total": {"lines":{"total":24,"covered":22,"skipped":0,"pct":91.67},"statements":{"total":26,"covered":24,"skipped":0,"pct":92.31},"functions":{"total":10,"covered":9,"skipped":0,"pct":90},"branches":{"total":4,"covered":2,"skipped":0,"pct":50}}
+,"C:\\Users\\David BOTTIAU\\Documents\\GitHub\\react-admin-import-csv\\src\\csv-extractor.ts": {"lines":{"total":24,"covered":22,"skipped":0,"pct":91.67},"functions":{"total":10,"covered":9,"skipped":0,"pct":90},"statements":{"total":26,"covered":24,"skipped":0,"pct":92.31},"branches":{"total":4,"covered":2,"skipped":0,"pct":50}}
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-admin": "3.x"
   },
   "dependencies": {
-    "papaparse": "4.x"
+    "papaparse": "4.x",
+    "ramda": "^0.27.0"
   },
   "devDependencies": {
     "@types/jest": "24.0.11",

--- a/src/csv-extractor.spec.ts
+++ b/src/csv-extractor.spec.ts
@@ -36,4 +36,15 @@ describe("csv extractor", () => {
     const data = await processCsvFile(file)
     expect(data).toHaveLength(5)
   });
+
+  test("process csv data with nested object", () => {
+    const output = processCsvData([
+      ["id", "item.title"],
+      ["1", "One"],
+      ["2", "Two"]
+    ]);
+    expect(output).toHaveLength(2)
+    expect(output[0].id).toBe("1")
+    expect(output[0].item.title).toBe("One")
+  });
 });

--- a/src/csv-extractor.ts
+++ b/src/csv-extractor.ts
@@ -1,4 +1,11 @@
 import { parse as convertFromCSV } from "papaparse";
+import lensPath from 'ramda/src/lensPath';
+import over from 'ramda/src/over';
+
+const setObjectValue = (object: any, path: string, value: any): any => {
+  const lensPathFunction = lensPath(path.split('.'));
+  return over(lensPathFunction, () => value, (object || {}));
+};
 
 export async function processCsvFile(file: File | any) {
   if (!file) {
@@ -18,14 +25,14 @@ export async function getCsvData(file: File | any) {
   );
 }
 
-export function processCsvData(data: string[][]): Object[] {
+export function processCsvData(data: string[][]): any[] {
   const topRowKeys: string[] = data[0];
 
   const dataRows = data.slice(1).map(row => {
-    const value: any = {};
+    let value: any = {};
 
     topRowKeys.forEach((key, index) => {
-      value[key] = row[index];
+      value = setObjectValue(value, key, row[index]);
     });
 
     return value;


### PR DESCRIPTION
Since we can use nested properties inside objects in react-admin, it is important to handle cases (extract values) where keys of the csv follow the `.` notation.