### PR TITLE
feat: skip empty csv lines

### DIFF
--- a/src/csv-extractor.ts
+++ b/src/csv-extractor.ts
@@ -12,6 +12,7 @@ export async function getCsvData(file: File | any) {
   return new Promise<string[][]>((resolve, reject) =>
     convertFromCSV(file, {
       delimiter: ",",
+      skipEmptyLines: true,
       complete: result => resolve(result.data),
       error: error => reject(error)
     })


### PR DESCRIPTION
It can happen that a CSV file will have empty lines. In this case, we should prevent any error to happen and force papaparse to skip those lines.