### PR TITLE
Button variant label

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,28 @@
+
+export default {
+    csv: {
+        main: {
+            "import": "Import"
+        },
+        error: {
+            errorNoId: "Required field",
+            importing: "Error importing",
+            emptyResource: "The 'resource' property was empty, did you pass in the {...props} to the ImportButton?"
+        },
+        alert: {
+            imported:"Imported",
+        },
+        dialog: {
+            importTo: "Import to",
+            dataFileReq:"Data file requirements",
+            extension:"Must be a '.csv' or '.tsv' file",
+            idColumn:"Must contain an 'id' column",
+            chooseFile: "Choose File",
+            processed: "Processed:",
+            rowCount: "Row Count:",
+            cancel: "Cancel",
+            importNew: "Import as New",
+            importOverride: "Import as Overwrite "
+        }
+    }
+};

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1,0 +1,28 @@
+
+export default {
+    csv: {
+        main: {
+            "import": "Importar"
+        },
+        error: {
+            errorNoId: "Campo requerido",
+            importing: "Error al importar",
+            emptyResource: "La propiedad 'resource' esta vacia. ¿Fue pasada {...props} al componente `ImportButton`?"
+        },
+        alert: {
+            imported:"Importado ",
+        },
+        dialog: {
+            importTo: "Importar para",
+            dataFileReq:"Requisitos del archivo",
+            extension:"Debe ser un archivo '.csv' o '.tsv'",
+            idColumn:"Debe contener una columna 'id'",
+            chooseFile: "Elija Archivo",
+            processed: "Procesado",
+            rowCount: "Cuenta de filas",
+            cancel: "Cancelar",
+            importNew: "Importar nuevo",
+            importOverride: "Importar y sobrescribir "
+        }
+    }
+};

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,5 @@
+
+import en from './en';
+import es from './es';
+
+export { en, es };

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import { Button as RAButton } from "react-admin";
+import { Button as RAButton, resolveBrowserLocale } from "react-admin";
 import GetAppIcon from "@material-ui/icons/GetApp";
 import { useNotify, useDataProvider } from "react-admin";
 import { processCsvFile } from "./csv-extractor";
+
+import englishMessages from './i18n/en'
+import spanishMessages from './i18n/es'
+import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import {
   Button,
@@ -13,14 +17,22 @@ import {
 } from "@material-ui/core";
 
 export const ImportButton = (props: any) => {
+  const messages = {
+    en: englishMessages,
+    es: spanishMessages
+  };
+  
+  const i18nProvider = polyglotI18nProvider(
+    locale => messages[locale] ? messages[locale] : messages.en,
+    resolveBrowserLocale()
+  );
+
   const { resource, parseConfig, logging } = props;
   if (logging) {
     console.log({ props });
   }
   if (!resource) {
-    throw new Error(
-      "the 'resource' prop was empty, did you pass in the {...props} to the ImportButton?"
-    );
+    throw new Error(i18nProvider.translate('csv.error.emptyResource'));
   }
 
   const [open, setOpen] = React.useState(false);
@@ -42,9 +54,9 @@ export const ImportButton = (props: any) => {
       await Promise.all(
         values.map((value) => dataProvider.create(resource, { data: value }))
       );
-      notify(`Imported ${fileName}`);
+      notify(`${i18nProvider.translate('csv.alert.imported')} ${fileName}`);
     } catch (error) {
-      notify(`Error importing ${fileName}, ${error}`);
+      notify(`${i18nProvider.translate('csv.error.importing')} ${fileName}, ${error}`);
     }
   };
 
@@ -56,9 +68,9 @@ export const ImportButton = (props: any) => {
           dataProvider.update(resource, { id: value.id, data: value })
         )
       );
-      notify(`Imported ${fileName}`);
+      notify(`${i18nProvider.translate('csv.alert.imported')} ${fileName}`);
     } catch (error) {
-      notify(`Error importing ${fileName}, ${error}`);
+      notify(`${i18nProvider.translate('csv.error.importing')} ${fileName}, ${error}`);
     }
   };
 
@@ -71,7 +83,7 @@ export const ImportButton = (props: any) => {
     try {
       const values = await processCsvFile(file, parseConfig);
       if (values.some((v) => !v.id)) {
-        throw new Error('Some rows have no value for the "id" column');
+        throw new Error(i18nProvider.translate('csv.error.noId'));
       }
       if (logging) {
         console.log({ values });
@@ -90,7 +102,7 @@ export const ImportButton = (props: any) => {
       <RAButton
         color="primary"
         component="span"
-        label="Import"
+        label={i18nProvider.translate('csv.main.import')}
         onClick={openImportDialog}
       >
         <GetAppIcon style={{ transform: "rotate(180deg)", fontSize: "20" }} />
@@ -102,21 +114,21 @@ export const ImportButton = (props: any) => {
         aria-describedby="alert-dialog-description"
       >
         <DialogTitle id="alert-dialog-title">
-          Import to "{resource}"
+          {i18nProvider.translate('csv.dialog.importTo')} "{resource}"
         </DialogTitle>
         <DialogContent>
           <div
             id="alert-dialog-description"
             style={{ fontFamily: "sans-serif" }}
           >
-            <p style={{ margin: "0px" }}>Data file requirements</p>
+            <p style={{ margin: "0px" }}>{i18nProvider.translate('csv.dialog.dataFileReq')}</p>
             <ol>
-              <li>Must be a '.csv' or '.tsv' file</li>
-              <li>Must contain an 'id' column</li>
+              <li>{i18nProvider.translate('csv.dialog.extension')}</li>
+              <li>{i18nProvider.translate('csv.dialog.idColumn')}</li>
             </ol>
 
             <Button variant="contained" component="label">
-              <span>Choose File</span>
+              <span>{i18nProvider.translate('csv.dialog.chooseFile')}</span>
               <GetAppIcon
                 style={{ transform: "rotate(180deg)", fontSize: "20" }}
               />
@@ -130,12 +142,12 @@ export const ImportButton = (props: any) => {
 
             {!!fileName && (
               <p style={{ marginBottom: "0px" }}>
-                Processed: <strong>{fileName}</strong>
+                {i18nProvider.translate('csv.dialog.processed')}: <strong>{fileName}</strong>
               </p>
             )}
             {!!values && (
               <p style={{ margin: "0px" }}>
-                Row Count: <strong>{values.length}</strong>
+                {i18nProvider.translate('csv.dialog.rowCount')}: <strong>{values.length}</strong>
               </p>
             )}
             {!!errorTxt && (
@@ -145,7 +157,7 @@ export const ImportButton = (props: any) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>
-            <span>Cancel</span>
+            <span>{i18nProvider.translate('csv.dialog.cancel')}</span>
           </Button>
           <Button
             disabled={!values}
@@ -153,7 +165,8 @@ export const ImportButton = (props: any) => {
             color="secondary"
             variant="contained"
           >
-            <span>Import as New</span>
+            {/* <span>Import as New</span> */}
+            <span>{i18nProvider.translate('csv.dialog.importNew')}</span>
           </Button>
           <Button
             disabled={!values}
@@ -161,7 +174,7 @@ export const ImportButton = (props: any) => {
             color="primary"
             variant="contained"
           >
-            <span>Import as Overwrite</span>
+            <span>{i18nProvider.translate('csv.dialog.importOverride')}</span>
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -4,8 +4,10 @@ import GetAppIcon from "@material-ui/icons/GetApp";
 import { useNotify, useDataProvider } from "react-admin";
 import { processCsvFile } from "./csv-extractor";
 
-import englishMessages from './i18n/en'
-import spanishMessages from './i18n/es'
+import englishMessages from 'ra-language-english';
+import spanishMessages from 'ra-language-spanish';
+
+import * as domainMessages from './i18n';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 
 import {
@@ -17,11 +19,12 @@ import {
 } from "@material-ui/core";
 
 export const ImportButton = (props: any) => {
+
   const messages = {
-    en: englishMessages,
-    es: spanishMessages
+    es: { ...spanishMessages, ...domainMessages.es },
+    en: { ...englishMessages, ...domainMessages.en },
   };
-  
+    
   const i18nProvider = polyglotI18nProvider(
     locale => messages[locale] ? messages[locale] : messages.en,
     resolveBrowserLocale()

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -14,6 +14,7 @@ import {
 
 export const ImportButton = (props: any) => {
   const { resource, parseConfig, logging } = props;
+  
   if (logging) {
     console.log({ props });
   }
@@ -21,6 +22,19 @@ export const ImportButton = (props: any) => {
     throw new Error(
       "the 'resource' prop was empty, did you pass in the {...props} to the ImportButton?"
     );
+  }
+  
+  let { variant, label, resourceName } = props
+  if(!label){
+    label = "Import";
+  }
+
+  if (!variant){
+    variant = "text";
+  }  
+
+  if (!resourceName){
+    resourceName = resource;
   }
 
   const [open, setOpen] = React.useState(false);
@@ -90,7 +104,8 @@ export const ImportButton = (props: any) => {
       <RAButton
         color="primary"
         component="span"
-        label="Import"
+        variant={variant}
+        label={label}
         onClick={openImportDialog}
       >
         <GetAppIcon style={{ transform: "rotate(180deg)", fontSize: "20" }} />
@@ -102,7 +117,7 @@ export const ImportButton = (props: any) => {
         aria-describedby="alert-dialog-description"
       >
         <DialogTitle id="alert-dialog-title">
-          Import to "{resource}"
+          Import to "{resourceName}"
         </DialogTitle>
         <DialogContent>
           <div


### PR DESCRIPTION
Added the ability pass modifiers for the CSV Import button as props. 
- Label: Allow label for the button to be configurable or default to "Import" 
- Variant: Allow for changing the look and feel of the button by using 'text' (default) or 'contained'
   + Can be used to import from CSV on an 'Empty' page using the 'contained' variant