### PR TITLE
Fix ids

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,28 +1,30 @@
-
 export default {
-    csv: {
-        main: {
-            "import": "Import"
-        },
-        error: {
-            errorNoId: "Required field",
-            importing: "Error importing",
-            emptyResource: "The 'resource' property was empty, did you pass in the {...props} to the ImportButton?"
-        },
-        alert: {
-            imported:"Imported",
-        },
-        dialog: {
-            importTo: "Import to",
-            dataFileReq:"Data file requirements",
-            extension:"Must be a '.csv' or '.tsv' file",
-            idColumn:"Must contain an 'id' column",
-            chooseFile: "Choose File",
-            processed: "Processed:",
-            rowCount: "Row Count:",
-            cancel: "Cancel",
-            importNew: "Import as New",
-            importOverride: "Import as Overwrite "
-        }
-    }
+  csv: {
+    main: {
+      import: 'Import',
+    },
+    error: {
+      noId: "Overwrite requires field 'id'",
+      hasId: "Create should not include field 'id'",
+      importing: 'Error importing',
+      emptyResource:
+        "The 'resource' property was empty, did you pass in the {...props} to the ImportButton?",
+    },
+    alert: {
+      imported: 'Imported',
+    },
+    dialog: {
+      importTo: 'Import to',
+      dataFileReq: 'Data file requirements',
+      extension: "Must be a '.csv' or '.tsv' file",
+      idColumnCreate: "Must not contain an 'id' column for new",
+      idColumnUpdate: "Must contain an 'id' column for overwrite",
+      chooseFile: 'Choose File',
+      processed: 'Processed',
+      rowCount: 'Row Count',
+      cancel: 'Cancel',
+      importNew: 'Import as New',
+      importOverride: 'Import as Overwrite ',
+    },
+  },
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1,28 +1,30 @@
-
 export default {
-    csv: {
-        main: {
-            "import": "Importar"
-        },
-        error: {
-            errorNoId: "Campo requerido",
-            importing: "Error al importar",
-            emptyResource: "La propiedad 'resource' esta vacia. ¿Fue pasada {...props} al componente `ImportButton`?"
-        },
-        alert: {
-            imported:"Importado ",
-        },
-        dialog: {
-            importTo: "Importar para",
-            dataFileReq:"Requisitos del archivo",
-            extension:"Debe ser un archivo '.csv' o '.tsv'",
-            idColumn:"Debe contener una columna 'id'",
-            chooseFile: "Elija Archivo",
-            processed: "Procesado",
-            rowCount: "Cuenta de filas",
-            cancel: "Cancelar",
-            importNew: "Importar nuevo",
-            importOverride: "Importar y sobrescribir "
-        }
-    }
+  csv: {
+    main: {
+      import: 'Importar',
+    },
+    error: {
+      noId: "Sobrescribir requiere el campo 'id'",
+      hasId: "Crear no debe incluir el campo 'id'",
+      importing: 'Error al importar',
+      emptyResource:
+        "La propiedad 'resource' esta vacia. ¿Fue pasada {...props} al componente `ImportButton`?",
+    },
+    alert: {
+      imported: 'Importado ',
+    },
+    dialog: {
+      importTo: 'Importar para',
+      dataFileReq: 'Requisitos del archivo',
+      extension: "Debe ser un archivo '.csv' o '.tsv'",
+      idColumCreate: "No debe contener una columna 'id' para nuevo",
+      idColumnUpdate: "Debe contener una columna 'id' para sobrescribir",
+      chooseFile: 'Elija Archivo',
+      processed: 'Procesado',
+      rowCount: 'Cuenta de filas',
+      cancel: 'Cancelar',
+      importNew: 'Importar nuevo',
+      importOverride: 'Importar y sobrescribir ',
+    },
+  },
 };

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -30,7 +30,7 @@ export const ImportButton = (props: any) => {
     resolveBrowserLocale()
   );
 
-  const { resource, parseConfig, logging } = props;
+  const { resource, parseConfig, logging, preCommitCallback } = props;
 
   if (logging) {
     console.log({ props });
@@ -39,7 +39,7 @@ export const ImportButton = (props: any) => {
     throw new Error(i18nProvider.translate('csv.error.emptyResource'));
   }
 
-  let { variant, label, resourceName, preCommitCallback } = props;
+  let { variant, label, resourceName } = props;
   if (!label) {
     label = i18nProvider.translate('csv.main.import');
   }
@@ -100,7 +100,7 @@ export const ImportButton = (props: any) => {
       if (values.some((v) => !v.id)) {
         throw new Error(i18nProvider.translate('csv.error.noId'));
       }
-      if (preCommitCallback) setValues(preCommitCallback(values));
+      if (preCommitCallback) setValues(preCommitCallback('overwrite', values));
       Promise.all(
         values.map((value) => dataProvider.update(resource, { id: value.id, data: value }))
       ).then(() => {


### PR DESCRIPTION
Added support to call a `preCommitCallback` function, useful when transmuting data being imported, especially around permissions & validations.

Moved `id` check to `handleSubmit` functions. For create no `id` should be present, for overwrite `id` should be present.

Added a loading spinner to indicate progress.

Modified `handleClose` to clear values and file name.

Added a `handleComplete` function to help with complete logic.