### PR TITLE
fix: handle papaparse header true

### DIFF
--- a/src/csv-extractor.ts
+++ b/src/csv-extractor.ts
@@ -42,17 +42,20 @@ export async function getCsvData(
 }
 
 export function processCsvData(data: string[][]): any[] {
-  const topRowKeys: string[] = data[0];
 
-  const dataRows = data.slice(1).map((row) => {
-    let value: any = {};
+  if (Array.isArray(data[0])) {
+    const topRowKeys: string[] = data[0];
 
-    topRowKeys.forEach((key, index) => {
-      value = setObjectValue(value, key, row[index]);
+    const dataRows = data.slice(1).map((row) => {
+      let value: any = {};
+
+      topRowKeys.forEach((key, index) => {
+        value = setObjectValue(value, key, row[index]);
+      });
+
+      return value;
     });
-
-    return value;
-  });
-
-  return dataRows;
+    return dataRows;
+  }
+  return data;
 }


### PR DESCRIPTION
Hi!

In this fork we fixed the handling of `header: true` option in papaparse config, with @VicenteVicente .

The function `processCsvData` receives as argument `data` assuming that it is an array of arrays.  In the case where `header: true` is selected, the function does not work properly. With this commit it will check if `data[0]` is an array and then run the actual code. On the other hand, using `header: true` option, `data` will be an array of objects which will be the return value of the function, because it follows the same expected format as the actual code returns.