### PR TITLE
fix: handle objects as values

### DIFF
--- a/src/csv-extractor.ts
+++ b/src/csv-extractor.ts
@@ -57,5 +57,13 @@ export function processCsvData(data: string[][]): any[] {
     });
     return dataRows;
   }
-  return data;
+  else {
+    const dataRows = [];
+    data.forEach( (obj) => {
+        let value: any = {}
+        for (let key in obj) value = setObjectValue(value, key, obj[key]);
+        dataRows.push(value);
+    });
+    return dataRows;
+  }
 }


### PR DESCRIPTION
Hi @benwinding !

With @VicenteVicente I'm working on a project where it's necessary to import values that are objects. This wasn't handled in the last PR where the parseConfig `header: true` is used. If you have any questions about it let us know and we can show you more information about this case!

Thank you!