### PR TITLE
Post upload report handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ const config: ImportConfig = {
   disableImportOverwrite?: boolean;
   // A function to translate the CSV rows on import 
   preCommitCallback?: (action: "create" | "overwrite", values: any[]) => any[];
+  // A function to handle row errors after import
+  postCommitCallback?: ([]) => any[];
   // Any option from the "papaparse" library 
   parseConfig?: {
     // SEE: https://www.papaparse.com/docs#config

--- a/demo/src/posts.js
+++ b/demo/src/posts.js
@@ -22,11 +22,14 @@ import { CreateButton } from "ra-ui-materialui";
 
 const ListActions = props => {
   const { className, basePath } = props;
+
   const config = {
     logging: true,
-    disableImportNew: true,
-    disableImportOverwrite: false,
+    reportCallback: report => console.log("Report", report),
+    disableImportNew: false,
+    disableImportOverwrite: false
   }
+
   return (
     <TopToolbar className={className}>
       <CreateButton basePath={basePath} />

--- a/demo/src/posts.js
+++ b/demo/src/posts.js
@@ -25,7 +25,7 @@ const ListActions = props => {
 
   const config = {
     logging: true,
-    reportCallback: report => console.log("Report", report),
+    postCommitCallback: report => console.log("Report", report),
     disableImportNew: false,
     disableImportOverwrite: false
   }

--- a/src/config.interface.ts
+++ b/src/config.interface.ts
@@ -2,7 +2,7 @@ import { ParseConfig } from "papaparse";
 
 export interface ImportConfig {
   logging?: boolean;
-  reportCallback?: () => any[];
+  postCommitCallback?: ([]) => any[];
   disableImportNew?: boolean;
   disableImportOverwrite?: boolean;
   parseConfig?: ParseConfig;

--- a/src/config.interface.ts
+++ b/src/config.interface.ts
@@ -2,8 +2,9 @@ import { ParseConfig } from "papaparse";
 
 export interface ImportConfig {
   logging?: boolean;
+  reportCallback?: () => any[];
   disableImportNew?: boolean;
   disableImportOverwrite?: boolean;
   parseConfig?: ParseConfig;
   preCommitCallback?: (action: "create" | "overwrite", values: any[]) => any[];
-}
+};

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -96,9 +96,7 @@ export const ImportButton = (props: any) => {
         throw new Error(i18nProvider.translate('csv.error.hasId'));
       }
       if (preCommitCallback) setValues(preCommitCallback('create', values));
-
       await create(dataProvider, resource, values, reportCallback)
-
       handleComplete();
     } catch (error) {
       handleComplete(error);
@@ -108,11 +106,10 @@ export const ImportButton = (props: any) => {
   const handleSubmitOverwrite = async () => {
     setImporting(true);
     try {
-      if(values.some((v) => !v.id)) {
+      if (values.some((v) => !v.id)) {
         throw new Error(i18nProvider.translate('csv.error.noId'));
       }
       if (preCommitCallback) setValues(preCommitCallback('overwrite', values));
-
       update(dataProvider, resource, values, reportCallback)
         .then(() => handleComplete())
         .catch(error => handleComplete(error));

--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -34,7 +34,7 @@ export const ImportButton = (props: any) => {
   const {
     parseConfig,
     logging,
-    reportCallback,
+    postCommitCallback,
     preCommitCallback,
     disableImportNew,
     disableImportOverwrite
@@ -96,7 +96,7 @@ export const ImportButton = (props: any) => {
         throw new Error(i18nProvider.translate('csv.error.hasId'));
       }
       if (preCommitCallback) setValues(preCommitCallback('create', values));
-      await create(dataProvider, resource, values, reportCallback)
+      await create(dataProvider, resource, values, postCommitCallback)
       handleComplete();
     } catch (error) {
       handleComplete(error);
@@ -110,7 +110,7 @@ export const ImportButton = (props: any) => {
         throw new Error(i18nProvider.translate('csv.error.noId'));
       }
       if (preCommitCallback) setValues(preCommitCallback('overwrite', values));
-      update(dataProvider, resource, values, reportCallback)
+      update(dataProvider, resource, values, postCommitCallback)
         .then(() => handleComplete())
         .catch(error => handleComplete(error));
     } catch (error) {

--- a/src/uploader.spec.ts
+++ b/src/uploader.spec.ts
@@ -1,0 +1,107 @@
+import { processCsvData, getCsvData, processCsvFile } from "./csv-extractor";
+
+import * as Uploader from "./uploader";
+
+import * as fs from "fs";
+import * as path from "path";
+
+function getFile(relPath: string): fs.ReadStream {
+  const testCsvPath = path.join(__dirname, relPath)
+  const csvFile = fs.createReadStream(testCsvPath)
+  return csvFile;
+}
+
+const success = (res, params) => Promise.resolve(params.data)
+const failure = (res, params) => (
+  params.data.id.match(/wqwq/) ?
+    Promise.reject("wqwq is bad") :
+    Promise.resolve(params.data))
+
+const defaults = {
+  resource: "dummy",
+  create: {
+    success,
+    failure
+  },
+  update: {
+    success,
+    failure
+  }
+}
+
+const expectOperation = (method, onMethod, onReport) => {
+
+  const dataProvider = { [ method ] : onMethod}
+
+  return processCsvFile(getFile('../test-csvs/test1.csv'))
+    .then(values => (
+      Uploader[method](
+        dataProvider,
+        defaults.resource,
+        values,
+        onReport)))
+}
+
+const expectCreate = (onCreate, onReport = null) => expectOperation('create', onCreate, onReport)
+
+const expectUpdate = (onUpdate, onReport = null) => expectOperation('update', onUpdate, onReport)
+
+describe("import csv button", () => {
+  describe("with reporting", () => {
+    test("happy path create", done => {
+      expectCreate(
+        defaults.create.success,
+        report => {
+           expect(report).toHaveLength(5)
+           expect(report.filter(r => r.success)).toHaveLength(5)
+           done()
+        })
+    });
+    
+    test("happy path update", done => {
+      expectUpdate(
+        defaults.update.success,
+        report => {
+           expect(report).toHaveLength(5)
+           expect(report.filter(r => r.success)).toHaveLength(5)
+           done()
+        })
+    })
+    test("server error path create", done => {
+      expectCreate(
+        defaults.create.failure,
+        report => {
+           expect(report.filter(r => r.success)).toHaveLength(4)
+           expect(report.filter(r => !r.success)).toHaveLength(1)
+           done()
+        })
+    })
+
+    test("server error path update", done => {
+      expectUpdate(
+        defaults.update.failure,
+        report => {
+           expect(report.filter(r => r.success)).toHaveLength(4)
+           expect(report.filter(r => !r.success)).toHaveLength(1)
+           done()
+        })
+    
+    })
+  })
+
+  describe("without reporting", () => {
+
+    test("happy path create", () => expectCreate(defaults.create.success))
+
+    test("happy path update", () => expectUpdate(defaults.update.success))
+
+    test("server error path create", done => {
+      expectCreate(defaults.create.failure)
+        .catch(() =>  done())
+    })
+    test("server error path update", done => {
+      expectUpdate(defaults.update.failure)
+        .catch(() => done())
+    })
+  })
+});

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -1,0 +1,35 @@
+export async function create(dataProvider, resource, values, reportCallback = null) {
+
+  if(reportCallback) {
+    const report = []
+    await Promise
+      .all(values.map((value) => dataProvider
+        .create(resource, { data: value })
+        .then(() => report.push({...value, success: true}))
+        .catch(err => report.push({...value, success: false, err}))))
+        .finally(() => reportCallback(report))
+    return;
+  }
+  else {
+    return Promise.all(values.map((value) => dataProvider.create(resource, { data: value })));
+  }
+}
+
+export async function update(dataProvider, resource, values, reportCallback = null) {
+  if(reportCallback) {
+    const report = []
+
+    await Promise
+      .all(values.map((value) => dataProvider
+        .update(resource, { id: value.id, data: value })
+        .then(() => report.push({...value, success: true}))
+        .catch(err => report.push({...value, success: false, err}))))
+        .finally(() => reportCallback(report));
+
+    return;
+  }
+  else {
+    return Promise.all(values.map((value) => dataProvider.update(resource, { id: value.id, data: value })))
+  };
+}
+

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -1,13 +1,13 @@
-export async function create(dataProvider, resource, values, reportCallback = null) {
+export async function create(dataProvider, resource, values, postCommitCallback = null) {
 
-  if(reportCallback) {
+  if(postCommitCallback) {
     const report = []
     await Promise
       .all(values.map((value) => dataProvider
         .create(resource, { data: value })
         .then(() => report.push({...value, success: true}))
         .catch(err => report.push({...value, success: false, err}))))
-        .finally(() => reportCallback(report))
+        .finally(() => postCommitCallback(report))
     return;
   }
   else {
@@ -15,8 +15,8 @@ export async function create(dataProvider, resource, values, reportCallback = nu
   }
 }
 
-export async function update(dataProvider, resource, values, reportCallback = null) {
-  if(reportCallback) {
+export async function update(dataProvider, resource, values, postCommitCallback = null) {
+  if(postCommitCallback) {
     const report = []
 
     await Promise
@@ -24,7 +24,7 @@ export async function update(dataProvider, resource, values, reportCallback = nu
         .update(resource, { id: value.id, data: value })
         .then(() => report.push({...value, success: true}))
         .catch(err => report.push({...value, success: false, err}))))
-        .finally(() => reportCallback(report));
+        .finally(() => postCommitCallback(report));
 
     return;
   }


### PR DESCRIPTION
The current api doesn't allow the client to deal with individual server-side failures since the Promise.all in the create/update functions are literally all or nothing.

As a solution, I added the "reportCallback" option which allows all of the dataProvider calls to finish successfully so that the Dialog can survive a failure, and allows the client to specify how to handle the results (which include error information) in their own code.

As an example, we handle reporting results like this...

`import {  downloadCSV
  } from 'react-admin'

import { unparse  } from 'papaparse/papaparse.min';

const reportCallback = results => downloadCSV(unparse(results))

...
< ImportButton reportCallback={reportCallback} / >
...
`