### PR TITLE
Bugfix: properly handle preCommitCallback results

### DIFF
--- a/src/import-csv-button.tsx
+++ b/src/import-csv-button.tsx
@@ -94,12 +94,19 @@ export const ImportButton = (props: any) => {
 
   const handleSubmitCreate = async () => {
     setImporting(true);
+
     try {
       if (values.some((v) => v.id)) {
         throw new Error(i18nProvider.translate('csv.error.hasId'));
       }
-      if (preCommitCallback) setValues(preCommitCallback('create', values));
-      await create(dataProvider, resource, values, postCommitCallback)
+
+      await create(
+        dataProvider,
+        resource,
+        preCommitCallback ? preCommitCallback('create', values) : values,
+        postCommitCallback
+      )
+
       handleComplete();
     } catch (error) {
       handleComplete(error);
@@ -108,14 +115,20 @@ export const ImportButton = (props: any) => {
 
   const handleSubmitOverwrite = async () => {
     setImporting(true);
+
     try {
       if (values.some((v) => !v.id)) {
         throw new Error(i18nProvider.translate('csv.error.noId'));
       }
-      if (preCommitCallback) setValues(preCommitCallback('overwrite', values));
-      update(dataProvider, resource, values, postCommitCallback)
-        .then(() => handleComplete())
-        .catch(error => handleComplete(error));
+
+      await update(
+        dataProvider,
+        resource,
+        preCommitCallback ? preCommitCallback('overwrite', values) : values,
+        postCommitCallback
+      )
+
+      handleComplete();
     } catch (error) {
       handleComplete(error);
     }


### PR DESCRIPTION
Hi, 

This PR fixes issues #25 

I changed the way `preCommitCallback` results are passed to `create` and `update` functions. This version does not call `setValues`, but this is not an issue since at that point row values in state are not used anymore. 

Now it works like a charm in my project 🙂

