### PR TITLE
Fix for reporting errors in fallback

### DIFF
--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -94,7 +94,7 @@ async function createInDataProvider(
       );
       try {
         const items = await createInDataProviderFallback(dataProvider, resource, values);
-        reportItems.concat(items);
+        reportItems.push(...items);
       } catch (error) {
         logger.error("addInDataProvider", error);
       }


### PR DESCRIPTION
In the fallback condition, there's a minor bug that means we don't get any items in the `postCommitCallback` method.