### PR TITLE
Fix comparison between id

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const config: ImportConfig = {
   // Disable "import overwrite" button 
   disableImportOverwrite?: boolean;
   // A function to translate the CSV rows on import 
-  preCommitCallback?: (action: "create" | "overwrite", values: any[]) => any[];
+  preCommitCallback?: (action: "create" | "overwrite", values: any[]) => Promise<any[]>;
   // A function to handle row errors after import
   postCommitCallback?: (error: any) => void;
   // Async function to Validate a row, reject the promise if it's not valid

--- a/demo/src/posts.js
+++ b/demo/src/posts.js
@@ -52,7 +52,7 @@ const ListActions = (props) => {
         filter={filterValues}
         exporter={exporter}
       />
-      <ImportButton {...props} {...config} />
+      <ImportButton {...props} {...config} parseConfig={{dynamicTyping: true}}/>
     </TopToolbar>
   );
 };

--- a/src/main-csv-button.tsx
+++ b/src/main-csv-button.tsx
@@ -92,7 +92,7 @@ export const MainCsvImport = (props: any) => {
       // Ask Replace X Rows? Skip these rows? Decied For Each?
       const collindingIdsSet = new Set(collidingIds.map((id) => id));
       const csvItemsNotColliding = csvItems.filter(
-        (item) => !collindingIdsSet.has(item.id)
+        (item) => !collindingIdsSet.has(item.id + '')
       );
       logger.log("Importing items which arent colliding", {
         csvItemsNotColliding,


### PR DESCRIPTION
Fix the comparison between id when id is number.
Without the modification in `src/main-csv-button.tsx`, when uploading a conflicting file, you'll see in the log that `csvItemsNotColliding` is still all the items uploaded.