### PR TITLE
feat: add postValidateCallback, add disableCollidingIdCheck

### DIFF
--- a/src/config.interface.ts
+++ b/src/config.interface.ts
@@ -6,7 +6,6 @@ export interface ImportConfig {
   disableImportNew?: boolean;
   disableImportOverwrite?: boolean;
   disableCollidingIdCheck?: boolean;
-  disableRefreshOnValidationErrors?: boolean;
   preCommitCallback?: PrecommitCallback;
   postCommitCallback?: ErrorCallback;
   transformRows?: (csvRows: any[]) => Promise<any[]>;

--- a/src/config.interface.ts
+++ b/src/config.interface.ts
@@ -5,12 +5,16 @@ export interface ImportConfig {
   parseConfig?: ParseConfig;
   disableImportNew?: boolean;
   disableImportOverwrite?: boolean;
+  disableCollidingIdCheck?: boolean;
+  disableRefreshOnValidationErrors?: boolean;
   preCommitCallback?: PrecommitCallback;
   postCommitCallback?: ErrorCallback;
   transformRows?: (csvRows: any[]) => Promise<any[]>;
   validateRow?: ValidateRowFunction;
+  postValidateCallback?: PostValidateCallback;
 };
 
 export type PrecommitCallback = (action: "create" | "overwrite", values: any[]) => Promise<any[]>;
-export type ValidateRowFunction = (csvRowItem: any, index?: any, allItems?: any[]) => Promise<void>;
+export type ValidateRowFunction = (csvRowItem: any, index?: any, allItems?: any[]) => Promise<any>;
+export type PostValidateCallback = (errors: any, csvItems: any[]) => Promise<void>;
 export type ErrorCallback = (error: any) => void;

--- a/src/import-controller.ts
+++ b/src/import-controller.ts
@@ -39,13 +39,13 @@ export async function CheckCSVValidation(
   translate: Translate,
   csvValues: any[],
   validateRow?: ValidateRowFunction
-): Promise<void> {
+): Promise<any[]> {
   const logger = makeLogger(logging);
   if (!validateRow) {
-    return;
+    return [];
   }
   try {
-    await Promise.all(csvValues.map(validateRow));
+    return await Promise.all(csvValues.map(validateRow)) || [];
   } catch (error) {
     logger.error("onFileAdded", { csvValues }, error);
     throw translate("csv.parsing.failedValidateRow");

--- a/src/main-csv-button.tsx
+++ b/src/main-csv-button.tsx
@@ -29,7 +29,6 @@ export const MainCsvImport = (props: any) => {
     disableImportNew,
     disableImportOverwrite,
     disableCollidingIdCheck,
-    disableRefreshOnValidationErrors,
   } = props as ImportConfig;
   const disableNew = !!disableImportNew;
   const disableOverwrite = !!disableImportOverwrite;


### PR DESCRIPTION
Added 2 optional props:
* optional: **disableCollidingIdCheck**
* optional: **postValidateCallback** - collects output from all validateRow function calls in case of wanting to e.g. return the imported file with all errors, rather than to end the validation after first errored row
